### PR TITLE
Updated to use the default BlankNode ID to avoid the hanging and UI display problem for now. DAMSKEY-553

### DIFF
--- a/src/main/java/edu/ucsd/library/floadr/Gloadr.java
+++ b/src/main/java/edu/ucsd/library/floadr/Gloadr.java
@@ -180,6 +180,11 @@ public class Gloadr {
                         log.info("skipping: " + linkPath );
                     }
 
+                    if ( linkPath.indexOf("#N") > 0 ) {
+                        final Node node = about.getParent();
+                        about.detach();
+                        ((Element)node).addAttribute("rdf:nodeID", linkPath.substring(linkPath.lastIndexOf("#") + 1));
+                    }
                 }
 
                 // separate components as top level objects and retain the component structure


### PR DESCRIPTION
https://lib-jira.ucsd.edu:8443/browse/DAMSKEY-553